### PR TITLE
Fix a couple of bugs that were producing invalid Swagger/JSON schema

### DIFF
--- a/lib/swagger_yard/model.rb
+++ b/lib/swagger_yard/model.rb
@@ -67,8 +67,10 @@ module SwaggerYard
     end
 
     def swagger_v2
-      { "properties" => @properties.inject({}) {|h, p| h.merge(p.name => p.swagger_v2)},
-        "required"   => @properties.select(&:required?).map(&:name) }
+      {}.tap do |h|
+        h["properties"] = Hash[@properties.map {|p| [p.name, p.swagger_v2]}]
+        h["required"] = @properties.select(&:required?).map(&:name) if @properties.detect(&:required?)
+      end
     end
   end
 end

--- a/lib/swagger_yard/type.rb
+++ b/lib/swagger_yard/type.rb
@@ -22,6 +22,22 @@ module SwaggerYard
 
     alias :array? :array
 
+    def json_type
+      type, format = name, nil
+      case name
+      when "float", "double"
+        type = "number"
+        format = name
+      when "date-time", "date", "time"
+        type = "string"
+        format = name
+      end
+      {}.tap do |h|
+        h["type"]   = type
+        h["format"] = format if format
+      end
+    end
+
     def to_h
       type_tag = ref? ? "$ref" : "type"
       if array?
@@ -35,7 +51,7 @@ module SwaggerYard
       type = if ref?
         { "$ref" => "#/definitions/#{name}"}
       else
-        { "type" => name }
+        json_type
       end
       if array?
         { "type" => "array", "items" => type }

--- a/spec/lib/swagger_yard/swagger_spec.rb
+++ b/spec/lib/swagger_yard/swagger_spec.rb
@@ -5,6 +5,12 @@ RSpec.describe SwaggerYard::Swagger do
 
   it_behaves_like SwaggerYard::Swagger
 
+  it "is valid" do
+    errors = Apivore::Swagger.new(swagger).validate
+    puts *errors unless errors.empty?
+    expect(errors).to be_empty
+  end
+
   context "#/paths//pets/{id}.{format_type}" do
     subject { swagger["paths"]["/pets/{id}.{format_type}"] }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ require 'bundler/setup'
 Bundler.require
 
 require 'rspec/its'
+require 'apivore'
 
 # Load Rails, which loads our swagger_yard
 # require File.expand_path('../fixtures/dummy/config/application.rb', __FILE__)

--- a/swagger_yard.gemspec
+++ b/swagger_yard.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rspec-its'
+  s.add_development_dependency 'apivore'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'mocha'
   s.add_development_dependency 'bourne'


### PR DESCRIPTION
- `required` should be omitted unless there is at least one required field.
- `float`/`double` are not valid JSON types -- type should be `number` with
  format set to `float`/`double`