### PR TITLE
Allow configuring of a path discovery function

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,3 +159,23 @@ ResourceListing
 -> Model (model)
   |
   -> Properties (model attributes)
+
+### Path Discovery Function ##
+
+SwaggerYard configuration allows setting of a "path discovery function" which
+will be called for controller action method documentation that have no `@path`
+tag.
+
+```ruby
+SwaggerYard.configure do |config|
+  config.path_discovery_function = ->(yard_obj) do
+    # code here to inspect the yard doc object
+	# and return a path for the api
+  end
+end
+```
+
+In [swagger_yard-rails][], this hook is used to set a function that inspects the
+Rails routing tables to reverse look up and compute paths.
+
+[swagger_yard-rails]: https://github.com/tpitale/swagger-yard_rails

--- a/lib/swagger_yard/api.rb
+++ b/lib/swagger_yard/api.rb
@@ -5,8 +5,8 @@ module SwaggerYard
     def self.path_from_yard_object(yard_object)
       if tag = yard_object.tags.detect {|t| t.tag_name == "path"}
         tag.text
-      else
-        nil
+      elsif fn = SwaggerYard.config.path_discovery_function
+        fn[yard_object]
       end
     end
 

--- a/lib/swagger_yard/configuration.rb
+++ b/lib/swagger_yard/configuration.rb
@@ -5,6 +5,7 @@ module SwaggerYard
     attr_accessor :title, :description
     attr_accessor :enable, :reload
     attr_accessor :controller_path, :model_path
+    attr_accessor :path_discovery_function
 
     def initialize
       self.swagger_version = "1.1"

--- a/spec/lib/swagger_yard/api_spec.rb
+++ b/spec/lib/swagger_yard/api_spec.rb
@@ -18,5 +18,30 @@ describe SwaggerYard::Api do
         expect(api.path).to eq("/accounts/ownerships.{format_type}")
       end
     end
+
+    context "with dynamic path discovery" do
+      let(:tags) { [] }
+
+      before(:each) do
+        yard_object.stubs(:tags).returns(tags)
+        SwaggerYard.configure do |config|
+          @prev_fn = config.path_discovery_function
+          config.path_discovery_function = -> obj do
+            expect(obj).to respond_to(:tags)
+            '/blah'
+          end
+        end
+      end
+
+      after(:each) do
+        SwaggerYard.configure do |config|
+          config.path_discovery_function = @prev_fn
+        end
+      end
+
+      it 'calls the provided function to determine the path' do
+        expect(api.path).to eq('/blah')
+      end
+    end
   end
 end


### PR DESCRIPTION
This will enable swagger_yard-rails to inject logic to inspect Rails routes for
path information and allow `@path` tags to be omitted in some cases.